### PR TITLE
Update version to 2.3.2 and add team_slug parameter to journal import and creation methods

### DIFF
--- a/opennote/async_sdk.py
+++ b/opennote/async_sdk.py
@@ -122,13 +122,14 @@ class AsyncJournalEditor:
     def __init__(self, client: "AsyncOpennoteClient"):
         self._client = client
 
-    async def import_from_markdown(self, markdown: str, title: Optional[str] = "Imported Journal", extra_headers: Optional[Dict[str, str]] = None, extra_body: Optional[Dict[str, Any]] = None) -> ImportFromMarkdownResponse:
+    async def import_from_markdown(self, markdown: str, title: Optional[str] = "Imported Journal", team_slug: Optional[str] = None, extra_headers: Optional[Dict[str, str]] = None, extra_body: Optional[Dict[str, Any]] = None) -> ImportFromMarkdownResponse:
         """
         Import a journal from markdown content asynchronously.
         
         Args:
             markdown: The markdown content to import
             title: Optional title for the journal (default: "Imported Journal")
+            team_slug: The team slug that the journal is associated with
             extra_headers: Additional headers to include in the request
             extra_body: Additional body parameters to include in the request
             
@@ -137,7 +138,8 @@ class AsyncJournalEditor:
         """
         request = ImportFromMarkdownRequest(
             markdown=markdown,
-            title=title
+            title=title,
+            team_slug=team_slug
         )
         
         response = await self._client._request(
@@ -228,19 +230,20 @@ class AsyncJournals:
         self._client = client
         self.editor = AsyncJournalEditor(client)
 
-    async def create(self, title: str, extra_headers: Optional[Dict[str, str]] = None, extra_body: Optional[Dict[str, Any]] = None) -> CreateJournalResponse:
+    async def create(self, title: str, team_slug: Optional[str] = None, extra_headers: Optional[Dict[str, str]] = None, extra_body: Optional[Dict[str, Any]] = None) -> CreateJournalResponse:
         """
         Create a new journal asynchronously.
         
         Args:
             title: The title of the journal
+            team_slug: The team slug that the journal is associated with, if the type is `team`
             extra_headers: Additional headers to include in the request
             extra_body: Additional body parameters to include in the request
             
         Returns:
             CreateJournalResponse with journal_id and journal_url
         """
-        request = CreateJournalRequest(title=title)
+        request = CreateJournalRequest(title=title, team_slug=team_slug)
         
         response = await self._client._request(
             "PUT",

--- a/opennote/sync_sdk.py
+++ b/opennote/sync_sdk.py
@@ -118,20 +118,22 @@ class JournalEditor:
     def __init__(self, client: "OpennoteClient"):
         self._client = client
 
-    def import_from_markdown(self, markdown: str, title: Optional[str] = "Imported Journal", extra_headers: Optional[Dict[str, str]] = None, extra_body: Optional[Dict[str, Any]] = None) -> ImportFromMarkdownResponse:
+    def import_from_markdown(self, markdown: str, title: Optional[str] = "Imported Journal", team_slug: Optional[str] = None, extra_headers: Optional[Dict[str, str]] = None, extra_body: Optional[Dict[str, Any]] = None) -> ImportFromMarkdownResponse:
         """
         Import a journal from markdown content.
         
         Args:
             markdown: The markdown content to import
             title: Optional title for the journal (default: "Imported Journal")
+            team_slug: The team slug that the journal is associated with
             
         Returns:
             ImportFromMarkdownResponse with journal_id and journal_url
         """
         request = ImportFromMarkdownRequest(
             markdown=markdown,
-            title=title
+            title=title,
+            team_slug=team_slug
         )
         
         response = self._client._request(
@@ -218,19 +220,20 @@ class Journals:
         self._client = client
         self.editor = JournalEditor(client)
 
-    def create(self, title: str, extra_headers: Optional[Dict[str, str]] = None, extra_body: Optional[Dict[str, Any]] = None) -> CreateJournalResponse:
+    def create(self, title: str, team_slug: Optional[str] = None, extra_headers: Optional[Dict[str, str]] = None, extra_body: Optional[Dict[str, Any]] = None) -> CreateJournalResponse:
         """
         Create a new journal.
         
         Args:
             title: The title of the journal
+            team_slug: The team slug that the journal is associated with, if the type is `team`
             extra_headers: Additional headers to include in the request
             extra_body: Additional body parameters to include in the request
             
         Returns:
             CreateJournalResponse with journal_id and journal_url
         """
-        request = CreateJournalRequest(title=title)
+        request = CreateJournalRequest(title=title, team_slug=team_slug)
         
         response = self._client._request(
             "PUT",

--- a/opennote/types/api_types.py
+++ b/opennote/types/api_types.py
@@ -163,8 +163,8 @@ class ImportFromMarkdownRequest(BaseModel):
     """Request model for importing a journal from markdown."""
     markdown: str = Field(description="The markdown content to import.")
     title: Optional[str] = Field(description="The title of the journal, if you want to provide one.", default="Imported Journal")
+    team_slug: Optional[str] = Field(description="The team slug that the journal is associated with", default=None)
 
-    # Allow extra fields for custom metadata
     class Config:
         extra = "allow"
 
@@ -212,23 +212,24 @@ class DeletedJournalData(BaseModel):
     content: str
     comments: List[Any]
     created_at: str
-    creator_id: str
     is_trashed: bool
     trashed_at: Optional[str] = None
     updated_at: str
     font_family: str
     parent_item: Optional[str] = None
-    shared_users: List[str]
     order_indexes: Optional[Any] = None
     publish_status: str
     pending_invites: Optional[Any] = None
-    user_permissions: dict[str, str]
     publish_subdomain: str
+    
+    class Config:
+        extra = "allow"
 
 
 class CreateJournalRequest(BaseModel):
     """Request model for creating a journal."""
     title: str = Field(description="The title of the journal.")
+    team_slug: Optional[str] = Field(description="The team slug that the journal is associated with, if the type is `team`.", default=None)
     
     class Config:
         extra = "allow"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="opennote",
-    version="2.3.1",
+    version="2.3.2",
     author="Opennote, Inc.",
     license="MIT",
     author_email="devtools@opennote.me",


### PR DESCRIPTION
- Incremented version in setup.py to 2.3.2.
- Added team_slug parameter to import_from_markdown and create methods in async_sdk.py and sync_sdk.py for better journal association.
- Updated request models in api_types.py to include team_slug for importing and creating journals.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-01 21:07:38 UTC

<h3>Summary</h3>
This PR adds team-based journal association functionality to the OpenNote Python SDK by introducing an optional `team_slug` parameter to journal import and creation methods. The changes enable users to associate journals with specific teams when importing from markdown or creating new journals, which is essential for multi-tenant or team-based environments where content needs to be properly scoped and organized.

The implementation adds the `team_slug` parameter consistently across both synchronous and asynchronous SDK methods (`import_from_markdown` and `create`), updates the underlying request models (`ImportFromMarkdownRequest` and `CreateJournalRequest`) in the API types, and increments the package version to 2.3.2 following semantic versioning conventions for a backward-compatible feature addition.

The changes maintain full backward compatibility by making the `team_slug` parameter optional with a default value of `None`. The parameter is properly integrated with the existing request serialization using `exclude_none=True`, ensuring that when not provided, it doesn't affect existing API behavior. This enhancement fits naturally into the existing SDK architecture and follows established patterns for parameter handling and method signatures.

Additionally, the PR includes a refactor of the `DeletedJournalData` model, removing several user-specific fields (`creator_id`, `shared_users`, `user_permissions`) and adding flexible configuration with `extra="allow"`, suggesting a shift towards a more dynamic permission system.

## Important Files Changed

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| setup.py | 5/5 | Standard version bump from 2.3.1 to 2.3.2 for semantic versioning |
| opennote/types/api_types.py | 4/5 | Added team_slug to request models and refactored DeletedJournalData structure |
| opennote/async_sdk.py | 5/5 | Added optional team_slug parameter to journal import and creation methods |
| opennote/sync_sdk.py | 5/5 | Added optional team_slug parameter to journal import and creation methods |

</details>

## Confidence score: 4/5

- This PR is safe to merge with minimal risk as it adds backward-compatible functionality
- Score reflects well-implemented optional parameter addition with proper integration, but slightly lowered due to the DeletedJournalData model changes that could affect downstream consumers
- Pay close attention to opennote/types/api_types.py due to the structural changes in DeletedJournalData model

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->